### PR TITLE
add chruby for ruby version management

### DIFF
--- a/zsh/chruby.zsh
+++ b/zsh/chruby.zsh
@@ -1,0 +1,3 @@
+source /opt/homebrew/opt/chruby/share/chruby/chruby.sh
+source /opt/homebrew/opt/chruby/share/chruby/auto.sh
+chruby ruby-2.7.5


### PR DESCRIPTION
Adds `chruby.zsh` file to YADR to allow use of `chruby` for ruby version management.